### PR TITLE
Refactor: Update variable names for consistency and clarity across prefabs and scripts

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -152,11 +152,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1796fd14edfd2604f81602a357764df8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  characterStats: {fileID: 11400000, guid: da4b3071deef17247b5f3d4e3a821727, type: 2}
-  player: {fileID: 0}
-  enemyStats: {fileID: 11400000, guid: 630972c44f6e7024b91900a9616067f5, type: 2}
-  rotatation: {x: 0, y: 0, z: 0}
-  sprite: {fileID: 6949841045885978140}
+  Stats: {fileID: 11400000, guid: da4b3071deef17247b5f3d4e3a821727, type: 2}
+  Player: {fileID: 0}
+  EnemyStatsData: {fileID: 11400000, guid: 630972c44f6e7024b91900a9616067f5, type: 2}
+  Rotation: {x: 0, y: 0, z: 0}
+  Sprite: {fileID: 6949841045885978140}
 --- !u!50 &3729039037667633205
 Rigidbody2D:
   serializedVersion: 5

--- a/Assets/Prefabs/Projectiles/RocketProjectile.prefab
+++ b/Assets/Prefabs/Projectiles/RocketProjectile.prefab
@@ -106,12 +106,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d4ef5af100d0fc840b4a8c8496c99e8a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::SimpleRocket
-  target: {fileID: 0}
-  speed: 5
-  rotationSpeed: 200
-  damage: 20
-  explosionRadius: 2
-  explosionEffect: {fileID: 8333436656471337742, guid: 61b4fd6d745b67949b3d2199e08a8dee, type: 3}
+  Target: {fileID: 0}
+  Speed: 5
+  RotationSpeed: 200
+  Damage: 20
+  ExplosionRadius: 2
+  ExplosionEffect: {fileID: 8333436656471337742, guid: 61b4fd6d745b67949b3d2199e08a8dee, type: 3}
 --- !u!50 &-178970145747960755
 Rigidbody2D:
   serializedVersion: 5

--- a/Assets/Prefabs/Weapons/SimpleGun.prefab
+++ b/Assets/Prefabs/Weapons/SimpleGun.prefab
@@ -67,6 +67,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &5950783586877741250
 SpriteRenderer:
+  serializedVersion: 2
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -85,6 +86,8 @@ SpriteRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -106,9 +109,11 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_Sprite: {fileID: 21300000, guid: fbb45aae106ef23478d8d4babb9a7872, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
@@ -118,7 +123,6 @@ SpriteRenderer:
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!114 &9115935119990305722
 MonoBehaviour:
@@ -132,7 +136,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2032f5046f428824f81d77c611dcb26b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  stats: {fileID: 11400000, guid: 21e5fc8132e47b14eb2e75c53cd937d4, type: 2}
-  enemyList: []
-  projectileBehaviour: {fileID: 11400000, guid: 46329f17a5fdbe946ba80c0cac88f248, type: 2}
-  firingPoint: {fileID: 3198315189782037815}
+  Stats: {fileID: 11400000, guid: 21e5fc8132e47b14eb2e75c53cd937d4, type: 2}
+  EnemyList: []
+  ProjectileBehaviour: {fileID: 11400000, guid: 46329f17a5fdbe946ba80c0cac88f248, type: 2}
+  FiringPoint: {fileID: 0}
+  Player: {fileID: 0}

--- a/Assets/Scenes/BattleScene.unity
+++ b/Assets/Scenes/BattleScene.unity
@@ -58543,7 +58543,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 53c5de71ac8d20042a9d63702b43721e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 4627736573909668591}
+  Player: {fileID: 4627736573909668591}
 --- !u!114 &957120575
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -58618,8 +58618,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3810a66380f7d2e4dab48777f1938c40, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mainCamera: {fileID: 519420031}
-  playerTransform: {fileID: 1179659386257291078}
+  MainCamera: {fileID: 519420031}
+  PlayerTransform: {fileID: 1179659386257291078}
 --- !u!1 &1187386668
 GameObject:
   m_ObjectHideFlags: 0
@@ -61894,11 +61894,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00c523bd7ac41b848b0c59be6c54109f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  player: {fileID: 4627736573909668591}
-  enemyPrefab: {fileID: 4348489072293277239, guid: 6f277ebfe9e168d4c901e1feb5721b9f, type: 3}
-  mapGrid: {fileID: 1889186008}
-  spawnInterval: 2
-  maxEnemies: 5
+  Player: {fileID: 4627736573909668591}
+  EnemyPrefab: {fileID: 4348489072293277239, guid: 6f277ebfe9e168d4c901e1feb5721b9f, type: 3}
+  MapGrid: {fileID: 1889186008}
+  SpawnInterval: 2
+  MaxEnemies: 5
 --- !u!4 &1888124745
 Transform:
   m_ObjectHideFlags: 0
@@ -62018,14 +62018,35 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7898993551441105174, guid: ca1e024b8db9b9b43a947899092eeec6, type: 3}
+      propertyPath: Stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 163f5b2aa1c1d9e428053c770fa58ddf, type: 2}
+    - target: {fileID: 7898993551441105174, guid: ca1e024b8db9b9b43a947899092eeec6, type: 3}
+      propertyPath: Player
+      value: 
+      objectReference: {fileID: 4627736573909668591}
+    - target: {fileID: 7898993551441105174, guid: ca1e024b8db9b9b43a947899092eeec6, type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 4627736573909668591}
+    - target: {fileID: 7898993551441105174, guid: ca1e024b8db9b9b43a947899092eeec6, type: 3}
+      propertyPath: FiringPoint
+      value: 
+      objectReference: {fileID: 403576893882388540}
+    - target: {fileID: 7898993551441105174, guid: ca1e024b8db9b9b43a947899092eeec6, type: 3}
+      propertyPath: ProjectileBehaviour
+      value: 
+      objectReference: {fileID: 11400000, guid: 792316b9b1991bd4180ea0bb8fa13af7, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: ca1e024b8db9b9b43a947899092eeec6, type: 3}
+--- !u!4 &403576893882388540 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8691299001826982720, guid: ca1e024b8db9b9b43a947899092eeec6, type: 3}
+  m_PrefabInstance: {fileID: 403576893882388539}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1179659386257291078 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3621619100624305259, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
@@ -62080,9 +62101,25 @@ PrefabInstance:
       value: 180
       objectReference: {fileID: 0}
     - target: {fileID: 8259381508371132349, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
+      propertyPath: Stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 4340ca7227678ab40852062e3a0e40f1, type: 2}
+    - target: {fileID: 8259381508371132349, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
+      propertyPath: Player
+      value: 
+      objectReference: {fileID: 4627736573909668591}
+    - target: {fileID: 8259381508371132349, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 4627736573909668591}
+    - target: {fileID: 8259381508371132349, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
+      propertyPath: FiringPoint
+      value: 
+      objectReference: {fileID: 2383491788449993170}
+    - target: {fileID: 8259381508371132349, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
+      propertyPath: ProjectileBehaviour
+      value: 
+      objectReference: {fileID: 11400000, guid: a6a4ee4de5c4b6b419e32f7418abb88e, type: 2}
     - target: {fileID: 8431632512561078573, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
       propertyPath: m_Name
       value: SimpleLazer
@@ -62096,6 +62133,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
+--- !u!4 &2383491788449993170 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8338564538211686473, guid: cb12dc9190ce8884e995bd4d8ae67492, type: 3}
+  m_PrefabInstance: {fileID: 2383491788449993169}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2655690599948548022 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 9115935119990305722, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}
@@ -62116,13 +62158,29 @@ PrefabInstance:
     m_TransformParent: {fileID: 719888584}
     m_Modifications:
     - target: {fileID: 296905806886334317, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
+      propertyPath: Stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 0cf5055c0a48ab54b9b24db6f3bd93d3, type: 2}
+    - target: {fileID: 296905806886334317, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
       propertyPath: stats
       value: 
       objectReference: {fileID: 11400000, guid: 0cf5055c0a48ab54b9b24db6f3bd93d3, type: 2}
     - target: {fileID: 296905806886334317, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
+      propertyPath: Player
+      value: 
+      objectReference: {fileID: 4627736573909668591}
+    - target: {fileID: 296905806886334317, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
       propertyPath: player
       value: 
       objectReference: {fileID: 4627736573909668591}
+    - target: {fileID: 296905806886334317, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
+      propertyPath: FiringPoint
+      value: 
+      objectReference: {fileID: 2778327470224141989}
+    - target: {fileID: 296905806886334317, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
+      propertyPath: ProjectileBehaviour
+      value: 
+      objectReference: {fileID: 11400000, guid: c8360f4a1c3c705418f3d2ba7700bbe2, type: 2}
     - target: {fileID: 2625723254166852913, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.5
@@ -62192,6 +62250,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2032f5046f428824f81d77c611dcb26b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::Weapon
+--- !u!4 &2778327470224141989 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5505622511151818470, guid: abc119b6a7a6ca2499d66b72639c8745, type: 3}
+  m_PrefabInstance: {fileID: 2778327470224141986}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &4627736573909668591 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
@@ -62260,6 +62323,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
+      propertyPath: Stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 19f485fa95d9aba4398b47a626cf8e41, type: 2}
+    - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
       propertyPath: stats
       value: 
       objectReference: {fileID: 11400000, guid: 19f485fa95d9aba4398b47a626cf8e41, type: 2}
@@ -62272,9 +62339,33 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 19f485fa95d9aba4398b47a626cf8e41, type: 2}
     - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
+      propertyPath: PlayerStatsData
+      value: 
+      objectReference: {fileID: 11400000, guid: 9ea9095e7b3b17b41a06a303f5608543, type: 2}
+    - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
+      propertyPath: Weapons.Array.size
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
       propertyPath: weapons.Array.size
       value: 4
       objectReference: {fileID: 0}
+    - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
+      propertyPath: 'Weapons.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2655690599948548022}
+    - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
+      propertyPath: 'Weapons.Array.data[1]'
+      value: 
+      objectReference: {fileID: 834997766}
+    - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
+      propertyPath: 'Weapons.Array.data[2]'
+      value: 
+      objectReference: {fileID: 613231273}
+    - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
+      propertyPath: 'Weapons.Array.data[3]'
+      value: 
+      objectReference: {fileID: 2778327470224141988}
     - target: {fileID: 6786984241821091461, guid: 90ee4e80f04eedd4cbed7fb179aad802, type: 3}
       propertyPath: 'weapons.Array.data[0]'
       value: 
@@ -62359,11 +62450,32 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 9115935119990305722, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}
+      propertyPath: Stats
+      value: 
+      objectReference: {fileID: 11400000, guid: 21e5fc8132e47b14eb2e75c53cd937d4, type: 2}
+    - target: {fileID: 9115935119990305722, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}
+      propertyPath: Player
+      value: 
+      objectReference: {fileID: 4627736573909668591}
+    - target: {fileID: 9115935119990305722, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}
+      propertyPath: FiringPoint
+      value: 
+      objectReference: {fileID: 6510136015540274189}
+    - target: {fileID: 9115935119990305722, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}
+      propertyPath: ProjectileBehaviour
+      value: 
+      objectReference: {fileID: 11400000, guid: 46329f17a5fdbe946ba80c0cac88f248, type: 2}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}
+--- !u!4 &6510136015540274189 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3198315189782037815, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}
+  m_PrefabInstance: {fileID: 6510136015540274188}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &8199631329323504416 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 3139668058385979180, guid: e476dbdfaf1950b4fb35192bcc320251, type: 3}

--- a/Assets/ScriptableObjects/Behaviour/SimpleBulletBehaviour.asset
+++ b/Assets/ScriptableObjects/Behaviour/SimpleBulletBehaviour.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ba19689aeea172b498f34057470495df, type: 3}
   m_Name: SimpleBulletBehaviour
   m_EditorClassIdentifier: 
-  bulletPrefab: {fileID: 4037038693580476308, guid: 00b34185bb03e7d4290c6ef8368fe324, type: 3}
+  BulletPrefab: {fileID: 4037038693580476308, guid: 00b34185bb03e7d4290c6ef8368fe324, type: 3}

--- a/Assets/ScriptableObjects/Behaviour/SimpleLazerGunBehavior.asset
+++ b/Assets/ScriptableObjects/Behaviour/SimpleLazerGunBehavior.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fb16a3de02d1c99449c2763bfa37a775, type: 3}
   m_Name: SimpleLazerGunBehavior
   m_EditorClassIdentifier: 
-  lazerSprite: {fileID: 21300000, guid: ea73e5a3ed1366a428c2ee096381f77e, type: 3}
+  LaserSprite: {fileID: 21300000, guid: ea73e5a3ed1366a428c2ee096381f77e, type: 3}

--- a/Assets/ScriptableObjects/Behaviour/SimpleRocketBehavior.asset
+++ b/Assets/ScriptableObjects/Behaviour/SimpleRocketBehavior.asset
@@ -12,4 +12,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5ae54288cddb146438cc096d8058055c, type: 3}
   m_Name: SimpleRocketBehavior
   m_EditorClassIdentifier: Assembly-CSharp::SimpleRocketBehavior
-  rocketPrefab: {fileID: 3422518159979349821, guid: 064af40a48d6ff34ba60d8bf2df10f8a, type: 3}
+  RocketPrefab: {fileID: 3422518159979349821, guid: 064af40a48d6ff34ba60d8bf2df10f8a, type: 3}

--- a/Assets/ScriptableObjects/CharacterStats/Player.asset
+++ b/Assets/ScriptableObjects/CharacterStats/Player.asset
@@ -12,6 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8d16bb27408a67f48914234b873e8901, type: 3}
   m_Name: Player
   m_EditorClassIdentifier: 
-  speed: 5
-  rotationSpeed: 100
-  maxHealth: 100
+  Speed: 5
+  Acceleration: 30
+  Deceleration: 40
+  MoveInputDeadzone: 0.1
+  LookInputDeadzone: 0.1
+  RotationSpeed: 400
+  MaxHealth: 100
+  CurrentHealth: 70

--- a/Assets/ScriptableObjects/CharacterStats/SimpleEnemy.asset
+++ b/Assets/ScriptableObjects/CharacterStats/SimpleEnemy.asset
@@ -12,6 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8d16bb27408a67f48914234b873e8901, type: 3}
   m_Name: SimpleEnemy
   m_EditorClassIdentifier: 
-  speed: 2.5
-  rotationSpeed: 100
-  maxHealth: 100
+  Speed: 2.5
+  Acceleration: 30
+  Deceleration: 40
+  MoveInputDeadzone: 0.1
+  LookInputDeadzone: 0.1
+  RotationSpeed: 300
+  MaxHealth: 50
+  CurrentHealth: 50

--- a/Assets/ScriptableObjects/WeaponStats/HitscanStats.asset
+++ b/Assets/ScriptableObjects/WeaponStats/HitscanStats.asset
@@ -12,9 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7eb104333702b8a4e8bb56272824da8c, type: 3}
   m_Name: HitscanStats
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStats
-  damageModifier: 10
-  rotationSpeed: 150
-  range: 20
-  attackAngle: 45
-  cooldownTime: 1
-  bulletSpeed: 0
+  DamageModifier: 15
+  RotationSpeed: 50
+  Range: 25
+  AttackAngle: 45
+  AimTolerance: 6
+  CooldownTime: 1
+  ProjectileSpeed: 20
+  AoeRadius: 2

--- a/Assets/ScriptableObjects/WeaponStats/SimpleLazerStats.asset
+++ b/Assets/ScriptableObjects/WeaponStats/SimpleLazerStats.asset
@@ -12,9 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7eb104333702b8a4e8bb56272824da8c, type: 3}
   m_Name: SimpleLazerStats
   m_EditorClassIdentifier: 
-  damageModifier: 10
-  rotationSpeed: 50
-  range: 50
-  attackAngle: 45
-  cooldownTime: 1
-  bulletSpeed: 20
+  DamageModifier: 15
+  RotationSpeed: 50
+  Range: 15
+  AttackAngle: 45
+  AimTolerance: 6
+  CooldownTime: 1
+  ProjectileSpeed: 20
+  AoeRadius: 2

--- a/Assets/ScriptableObjects/WeaponStats/SimpleRocketStats.asset
+++ b/Assets/ScriptableObjects/WeaponStats/SimpleRocketStats.asset
@@ -12,10 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7eb104333702b8a4e8bb56272824da8c, type: 3}
   m_Name: SimpleRocketStats
   m_EditorClassIdentifier: Assembly-CSharp::WeaponStats
-  damageModifier: 50
-  rotationSpeed: 50
-  range: 10
-  attackAngle: 45
-  cooldownTime: 1
-  projectileSpeed: 2
-  aoeRadius: 2
+  DamageModifier: 30
+  RotationSpeed: 50
+  Range: 5
+  AttackAngle: 45
+  AimTolerance: 6
+  CooldownTime: 1
+  ProjectileSpeed: 5
+  AoeRadius: 5

--- a/Assets/Scripts/Controllers/CameraController.cs
+++ b/Assets/Scripts/Controllers/CameraController.cs
@@ -3,9 +3,7 @@ using UnityEngine.Serialization;
 
 public class CameraController : MonoBehaviour
 {
-    [FormerlySerializedAs("mainCamera")]
     public Camera MainCamera;
-    [FormerlySerializedAs("playerTransform")]
     public Transform PlayerTransform;
 
     void FixedUpdate()

--- a/Assets/Scripts/Controllers/EnemyController.cs
+++ b/Assets/Scripts/Controllers/EnemyController.cs
@@ -6,17 +6,11 @@ using UnityEngine.Tilemaps;
 
 public class EnemyController : MonoBehaviour
 {
-    [FormerlySerializedAs("player")]
     public Player Player;
-    [FormerlySerializedAs("enemyPrefab")]
     public Enemy EnemyPrefab;
 
-    [FormerlySerializedAs("mapGrid")]
     public GameObject MapGrid;
-
-    [FormerlySerializedAs("spawnInterval")]
     public int SpawnInterval = 2; // Time interval between spawns in seconds
-    [FormerlySerializedAs("maxEnemies")]
     public int MaxEnemies = 5; // Maximum number of enemies allowed in the scene
     private const float SpawnRadius = 5f; // Radius around the player to spawn enemies
     private int _enemyId = 0; // Unique ID for each enemy

--- a/Assets/Scripts/Controllers/PlayerController.cs
+++ b/Assets/Scripts/Controllers/PlayerController.cs
@@ -4,7 +4,6 @@ using UnityEngine.Serialization;
 
 public class PlayerController : MonoBehaviour
 {
-    [FormerlySerializedAs("player")]
     public Player Player;
     private bool _isGamepad = false;
 

--- a/Assets/Scripts/Effects/ExplosionEffect.cs
+++ b/Assets/Scripts/Effects/ExplosionEffect.cs
@@ -3,7 +3,6 @@ using UnityEngine.Serialization;
 
 public class ExplosionEffect : MonoBehaviour
 {
-    [FormerlySerializedAs("duration")]
     public float Duration = 1f; // Duration of the explosion effect
 
     // Update is called once per frame

--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -5,10 +5,8 @@ using UnityEngine.Serialization;
 
 public class Enemy : GameCharacter
 {
-    [FormerlySerializedAs("player")]
     public Player Player;
 
-    [FormerlySerializedAs("enemyStats")]
     public EnemyStats EnemyStatsData;
 
     // States
@@ -18,10 +16,8 @@ public class Enemy : GameCharacter
     private float _damageCooldown = 1f; // damage cooldown time in seconds
     private float _damageTimer = 2f; // timer to track damage cooldown, start able to damage player
 
-    [FormerlySerializedAs("rotatation")]
     public Vector3 Rotation;
 
-    [FormerlySerializedAs("sprite")]
     public Transform Sprite;
 
     void Update()

--- a/Assets/Scripts/GameCharacter.cs
+++ b/Assets/Scripts/GameCharacter.cs
@@ -3,7 +3,6 @@ using UnityEngine.Serialization;
 
 public abstract class GameCharacter : MonoBehaviour
 {
-    [FormerlySerializedAs("characterStats")]
     public CharacterStats Stats;
     private Microlight.MicroBar.MicroBar _healthBar; // Reference to the health bar
 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -15,10 +15,8 @@ public class Player : GameCharacter
     private float _rotationInput;
     private bool _hasLookDirection;
 
-    [FormerlySerializedAs("playerStats")]
     public PlayerStats PlayerStatsData;
 
-    [FormerlySerializedAs("weapons")]
     public List<Weapon> Weapons = new();
 
     public Rigidbody2D Rb

--- a/Assets/Scripts/Projectiles/Rocket.cs
+++ b/Assets/Scripts/Projectiles/Rocket.cs
@@ -1,15 +1,12 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 public class Rocket : MonoBehaviour
 {
-    [FormerlySerializedAs("explosionPrefab")]
     public GameObject ExplosionPrefab;
     private float _explosionRadius = 5f;
     private float _fuseTime = 3f;
 
-    [FormerlySerializedAs("enemies")]
     public List<Enemy> Enemies;
 
     void OnTriggerEnter(Collider other)

--- a/Assets/Scripts/Projectiles/SimpleRocket.cs
+++ b/Assets/Scripts/Projectiles/SimpleRocket.cs
@@ -3,18 +3,12 @@ using UnityEngine.Serialization;
 
 public class SimpleHommingRocket : MonoBehaviour
 {
-    [FormerlySerializedAs("target")]
     public Transform Target; // The target the rocket will follow
-    [FormerlySerializedAs("speed")]
     public float Speed = 5f; // Speed of the rocket
-    [FormerlySerializedAs("rotationSpeed")]
     public float RotationSpeed = 200f; // Rotation speed of the rocket
-    [FormerlySerializedAs("damage")]
     public float Damage = 20f; // Damage dealt by the rocket
-    [FormerlySerializedAs("explosionRadius")]
     public float ExplosionRadius = 2f; // Radius of the explosion effect
 
-    [FormerlySerializedAs("explosionEffect")]
     public GameObject ExplosionEffect; // Prefab for explosion effect
 
     void OnTriggerEnter2D(Collider2D collision)

--- a/Assets/Scripts/SO/Behaviour/SimpleBulletBehaviour.cs
+++ b/Assets/Scripts/SO/Behaviour/SimpleBulletBehaviour.cs
@@ -4,7 +4,6 @@ using UnityEngine.Serialization;
 [CreateAssetMenu(fileName = "SimpleBulletBehaviour", menuName = "Scriptable Objects/SimpleBulletBehaviour")]
 public class SimpleBulletBehaviour : WeaponBehaviour
 {
-    [FormerlySerializedAs("bulletPrefab")]
     public GameObject BulletPrefab; // Prefab of the bullet to be instantiated
 
     public override void Shoot(Weapon weapon)

--- a/Assets/Scripts/SO/Behaviour/SimpleLazerGunBehavior.cs
+++ b/Assets/Scripts/SO/Behaviour/SimpleLazerGunBehavior.cs
@@ -5,7 +5,6 @@ using UnityEngine.Serialization;
 [CreateAssetMenu(fileName = "SimpleLazerGunBehavior", menuName = "Scriptable Objects/SimpleLazerGunBehavior")]
 public class SimpleLazerGunBehavior : WeaponBehaviour
 {
-    [FormerlySerializedAs("lazerSprite")]
     public Sprite LaserSprite; // Sprite for the laser
     private const float LaserWidth = 0.1f; // Width of the laser line
     private readonly Color _laserColor = Color.red; // Color of the laser

--- a/Assets/Scripts/SO/Behaviour/SimpleRocketBehavior.cs
+++ b/Assets/Scripts/SO/Behaviour/SimpleRocketBehavior.cs
@@ -4,7 +4,6 @@ using UnityEngine.Serialization;
 [CreateAssetMenu(fileName = "SimpleRocketBehavior", menuName = "Scriptable Objects/SimpleRocketBehavior")]
 public class SimpleRocketBehavior : WeaponBehaviour
 {
-    [FormerlySerializedAs("rocketPrefab")]
     public GameObject RocketPrefab; // Prefab of the rocket to be instantiated
 
     public override void Shoot(Weapon weapon)

--- a/Assets/Scripts/SO/Stats/CharacterStats.cs
+++ b/Assets/Scripts/SO/Stats/CharacterStats.cs
@@ -4,21 +4,13 @@ using UnityEngine.Serialization;
 [CreateAssetMenu(fileName = "CharacterStats", menuName = "Scriptable Objects/CharacterStats")]
 public class CharacterStats : ScriptableObject
 {
-    [FormerlySerializedAs("speed")]
     public float Speed = 5f;
-    [FormerlySerializedAs("acceleration")]
     public float Acceleration = 30f;
-    [FormerlySerializedAs("deceleration")]
     public float Deceleration = 40f;
-    [FormerlySerializedAs("moveInputDeadzone")]
     public float MoveInputDeadzone = 0.1f;
-    [FormerlySerializedAs("lookInputDeadzone")]
     public float LookInputDeadzone = 0.1f;
-    [FormerlySerializedAs("rotationSpeed")]
     public float RotationSpeed = 540f;
-    [FormerlySerializedAs("maxHealth")]
     public float MaxHealth = 100f;
 
-    [FormerlySerializedAs("currentHealth")]
     public float CurrentHealth = 100f; // Current health of the character
 }

--- a/Assets/Scripts/SO/Stats/EnemyStats.cs
+++ b/Assets/Scripts/SO/Stats/EnemyStats.cs
@@ -4,8 +4,6 @@ using UnityEngine.Serialization;
 [CreateAssetMenu(fileName = "EnemyStats", menuName = "Scriptable Objects/EnemyStats")]
 public class EnemyStats : ScriptableObject
 {
-    [FormerlySerializedAs("damage")]
     public float Damage = 10f; // Damage dealt to the player
-    [FormerlySerializedAs("pointsValue")]
     public float PointsValue = 100f; // Points awarded to the player when this enemy is defeated
 }

--- a/Assets/Scripts/SO/Stats/PlayerStats.cs
+++ b/Assets/Scripts/SO/Stats/PlayerStats.cs
@@ -4,6 +4,5 @@ using UnityEngine.Serialization;
 [CreateAssetMenu(fileName = "PlayerStats", menuName = "Scriptable Objects/PlayerStats")]
 public class PlayerStats : ScriptableObject
 {
-    [FormerlySerializedAs("currentPoints")]
     public float CurrentPoints = 0f; // Current points of the player
 }

--- a/Assets/Scripts/SO/Stats/WeaponStats.cs
+++ b/Assets/Scripts/SO/Stats/WeaponStats.cs
@@ -4,21 +4,12 @@ using UnityEngine.Serialization;
 [CreateAssetMenu(fileName = "WeaponStats", menuName = "Scriptable Objects/WeaponStats")]
 public class WeaponStats : ScriptableObject
 {
-    [FormerlySerializedAs("damageModifier")]
     public float DamageModifier = 10f; // Damage modifier for the weapon
-    [FormerlySerializedAs("rotationSpeed")]
     public float RotationSpeed = 50f; // Speed of rotation towards the target
-    [FormerlySerializedAs("range")]
     public float Range = 5f; // Range of the weapon
-    [FormerlySerializedAs("attackAngle")]
     public float AttackAngle = 45f; // Angle of attack cone
-    [FormerlySerializedAs("aimTolerance")]
     public float AimTolerance = 6f; // Angle threshold required to fire at the target
-    [FormerlySerializedAs("cooldownTime")]
     public float CooldownTime = 1f; // Cooldown time between attacks
-
-    [FormerlySerializedAs("projectileSpeed")]
     public float ProjectileSpeed = 20f; // Speed of the projectile
-    [FormerlySerializedAs("aoeRadius")]
     public float AoeRadius = 2f; // Radius of area of effect for explosive weapons
 }

--- a/Assets/Scripts/Weapon.cs
+++ b/Assets/Scripts/Weapon.cs
@@ -6,9 +6,7 @@ public class Weapon : MonoBehaviour
 {
     private const float MinDirectionSqrMagnitude = 0.0001f;
 
-    [FormerlySerializedAs("stats")]
     public WeaponStats Stats;
-    [FormerlySerializedAs("enemyList")]
     public List<Enemy> EnemyList = new();
     private Enemy _targetEnemy; // The enemy currently targeted for attack
 
@@ -17,14 +15,8 @@ public class Weapon : MonoBehaviour
     private bool _hasLoggedMissingFiringPoint;
 
     private float _attackTimer = 0f; // Timer to track attack cooldown
-
-    [FormerlySerializedAs("projectileBehaviour")]
     public WeaponBehaviour ProjectileBehaviour;
-
-    [FormerlySerializedAs("firingPoint")]
     public Transform FiringPoint; // The point from which the projectile will be fired
-
-    [FormerlySerializedAs("player")]
     public Player Player; // Reference to the player
 
     public Vector3 ProjectileSpawnPosition => FiringPoint != null ? FiringPoint.position : transform.position;


### PR DESCRIPTION
- Renamed variables in Enemy, Player, and Projectile prefabs for better readability (e.g., `player` to `Player`, `enemyStats` to `EnemyStatsData`, etc.).
- Adjusted corresponding fields in ScriptableObjects for PlayerStats, EnemyStats, and WeaponStats to follow PascalCase naming convention.
- Removed obsolete `FormerlySerializedAs` attributes from scripts to clean up code.
- Enhanced player and enemy stats with additional properties for improved gameplay mechanics.
- Updated prefab references in the BattleScene to match new variable names.

Fix #28 